### PR TITLE
docs: apply feedback from junior dev, senior dev, and tech lead personas

### DIFF
--- a/site/docs/analyze-first/dependency-insight.md
+++ b/site/docs/analyze-first/dependency-insight.md
@@ -12,6 +12,12 @@ This recipe provides detailed insight into a dependency's usage across your proj
 
 You can run the search recipe using one of the following methods, after creating a local `rewrite.yml` file in your project.
 
+:::tip Pin versions in CI
+
+Throughout this workshop we use `LATEST` (Maven) and `latest.release` (Gradle) so you always get the newest recipes. For reproducible CI and production builds, pin a specific version instead (e.g. `<version>1.54.0</version>`).
+
+:::
+
 ```yaml
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/site/docs/further-resources.md
+++ b/site/docs/further-resources.md
@@ -6,6 +6,14 @@ sidebar_position: 10
 
 Here are some additional resources to help you learn more about the topics covered in this workshop:
 
+## Bringing this back to your team
+
+- Pilot one low-risk recipe (e.g. [Dependency Insight](./analyze-first/dependency-insight)) on a single repository before scaling across the team.
+- Run a 1-hour dependency review with your team, using [Generate DevCenter](./analyze-first/generate-devcenter) to highlight concrete upgrade candidates.
+- Add a recurring DevCenter review to an existing ritual (sprint planning, architecture review, ops check-in) to keep migrations visible.
+- Install the [Moderne CLI](https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro) in CI so drift and new deprecations surface automatically.
+- Pair a teammate through [Upgrade your projects](./category/upgrade-your-projects/) against one of your real repositories to build shared experience.
+
 ## Automated Migration and Modernization
 - [OpenRewrite Documentation](https://docs.openrewrite.org/): Official documentation for OpenRewrite, including recipes and usage instructions.
 - [Moderne Documentation](https://docs.moderne.io/): Comprehensive guides and references for using Moderne, to scale up your efforts.

--- a/site/docs/intro.md
+++ b/site/docs/intro.md
@@ -12,8 +12,11 @@ This workshop consists of several sections, each focusing on a different aspect 
 1. [Outdated patterns](./category/outdated-patterns/) - We'll dive deeper into common legacy testing frameworks and libraries that are still in use today.
 1. [JUnit Jupiter](./category/junit-jupiter/) - Next, we'll upgrade to JUnit 6 and learn its new features.
 1. [Adopt AssertJ](./category/adopt-assertj/) - Then, we'll dive into AssertJ for more expressive assertions.
-1. [Upgrade your projects](./category/upgrade-your-projects) - Next, we'll apply what we've learned to upgrade real-world projects.
+1. [Upgrade your projects](./category/upgrade-your-projects/) - Next, we'll apply what we've learned to upgrade real-world projects.
+1. [Secure your projects](./category/secure-your-projects/) - We'll scan for vulnerable dependencies and remediate common OWASP findings.
 1. [Recipe development](./category/recipe-development/) - Finally, we'll learn how to create custom OpenRewrite recipes to automate improvements in your own codebases.
+
+When you're done, see [Further resources](./further-resources) for links to keep learning.
 
 ## Getting Started
 
@@ -28,6 +31,12 @@ cd migration-engineering-with-openrewrite
 
 This repository contains example code that you'll use throughout the workshop to explore the topics, write tests, and practice refactoring techniques.
 
+The repository has three top-level directories you should know about:
+
+- `books/` - Example projects that the recipes get applied to. You'll see before/after transformations here.
+- `recipes/` - Refaster templates and tests you'll complete in the [Recipe development](./category/recipe-development/) section.
+- `site/` - This documentation site. You generally won't edit anything here.
+
 ### Workshop structure
 
 We recommend going through the sections in order, but you're welcome to go at your own pace.
@@ -36,8 +45,13 @@ You're also welcome to use your own projects to try out the improvements alongsi
 
 ### What you'll need
 
-- Java 8+, to run recipes
-- [Moderne CLI](https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro) (recommended)
-- Gradle 4.10+, or
-- Maven 3+
-- Java 25, to develop recipes
+To run recipes (sections 1-6):
+
+- Java 8+
+- [Moderne CLI](https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro) (recommended), or
+- Maven 3+, or
+- Gradle 4.10+
+
+To develop your own recipes (the [Recipe development](./category/recipe-development/) section only):
+
+- Java 25


### PR DESCRIPTION
## Summary

Walked the workshop as three simulated participants and applied their top friction point each:

- **Junior dev** — `site/docs/intro.md`: section list now matches the real 7-category sidebar (added `secure-your-projects`, linked `further-resources`), Java 8/Java 25 requirements are split by workshop stage, and a new paragraph orients readers to the `books/`, `recipes/`, `site/` directories.
- **Senior dev** — `site/docs/analyze-first/dependency-insight.md`: one `:::tip` admonition explains that `LATEST`/`latest.release` is intentional for the workshop but should be pinned in CI/production.
- **Tech lead** — `site/docs/further-resources.md`: new "Bringing this back to your team" section with actionable rollout bullets (pilot, DevCenter hour, recurring review, CI drift detection, pair with a teammate).

## Test plan

- [x] `npm run build` in `site/` succeeds with no broken-link warnings.