### PR TITLE
Port workshop polish from break-your-testing-habits

### DIFF
--- a/site/docs/intro.md
+++ b/site/docs/intro.md
@@ -8,13 +8,21 @@ Today, we're going to apply migration engineering with OpenRewrite.
 
 This workshop consists of several sections, each focusing on a different aspect of improving your code.
 
-1. [Analyze first](./category/analyze-first/) - Starting out, we'll find what you're currently using, and how that would need to change.
-1. [Outdated patterns](./category/outdated-patterns/) - We'll dive deeper into common legacy testing frameworks and libraries that are still in use today.
-1. [JUnit Jupiter](./category/junit-jupiter/) - Next, we'll upgrade to JUnit 6 and learn its new features.
-1. [Adopt AssertJ](./category/adopt-assertj/) - Then, we'll dive into AssertJ for more expressive assertions.
-1. [Upgrade your projects](./category/upgrade-your-projects/) - Next, we'll apply what we've learned to upgrade real-world projects.
-1. [Secure your projects](./category/secure-your-projects/) - We'll scan for vulnerable dependencies and remediate common OWASP findings.
-1. [Recipe development](./category/recipe-development/) - Finally, we'll learn how to create custom OpenRewrite recipes to automate improvements in your own codebases.
+| # | Section | Time | Level |
+|---|---------|------|-------|
+| 1 | [Analyze first](./category/analyze-first/) - Find what you're currently using, and how that would need to change. | ~30 min | Beginner |
+| 2 | [Outdated patterns](./category/outdated-patterns/) - Common legacy testing frameworks and libraries that are still in use today. | ~45 min | Beginner |
+| 3 | [JUnit Jupiter](./category/junit-jupiter/) - Migrate to JUnit 5 (Jupiter), learn about JUnit 6, and explore features like parameterized and nested tests. | ~45 min | Beginner - Intermediate |
+| 4 | [Adopt AssertJ](./category/adopt-assertj/) - Dive into AssertJ for more expressive assertions. | ~60 min | Intermediate |
+| 5 | [Upgrade your projects](./category/upgrade-your-projects/) - Apply what we've learned to upgrade real-world projects. | ~75 min | Intermediate |
+| 6 | [Secure your projects](./category/secure-your-projects/) - Scan for vulnerable dependencies and remediate common OWASP findings. | ~30 min | Beginner - Intermediate |
+| 7 | [Recipe development](./category/recipe-development/) - Create custom OpenRewrite recipes to automate improvements in your own codebases. | ~60 min | Advanced (optional) |
+
+:::tip
+
+**Short on time?** Sections 1-4 form a self-contained "quick wins" track (~3 hours) that covers the most impactful improvements. Sections 5-7 go deeper and can be tackled later.
+
+:::
 
 When you're done, see [Further resources](./further-resources) for links to keep learning.
 

--- a/site/docs/recipe-development/recipe-development.md
+++ b/site/docs/recipe-development/recipe-development.md
@@ -302,8 +302,8 @@ Use the OpenRewrite Maven plugin to apply recipes to a codebase:
 ```bash
 cd /path/to/target/codebase
 mvn org.openrewrite.maven:rewrite-maven-plugin:run \
-  -Drewrite.recipeArtifactCoordinates=org.openrewrite:recipes:1.0-SNAPSHOT \
-  -Drewrite.activeRecipes=org.openrewrite.AssertToAssertThatRecipesForTests
+  --define rewrite.recipeArtifactCoordinates=org.openrewrite:recipes:1.0-SNAPSHOT \
+  --define rewrite.activeRecipes=org.openrewrite.AssertToAssertThatRecipesForTests
 ```
 
 ## Debugging Tips

--- a/site/docs/upgrade-your-projects/rollout-order.md
+++ b/site/docs/upgrade-your-projects/rollout-order.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 10
+---
+
+# Recommended rollout order
+
+When upgrading testing practices across multiple projects, the order matters. Each step produces a focused, reviewable set of changes. Run them one at a time, review the diff, and merge before proceeding to the next step.
+
+## Step-by-step sequence
+
+| Step | Recipe / Action | Why this order? |
+|------|----------------|-----------------|
+| 1 | [Change test method signatures](./change-test-method-signatures.md) | Small, safe changes (remove `public`, remove `test` prefix). Easy to review and merge. Reduces noise in subsequent diffs. |
+| 2 | Migrate JUnit 4 to JUnit 5 (Jupiter) | Updates annotations and imports. Best done after signature cleanup so the diff is focused on the framework migration. |
+| 3 | Adopt AssertJ | Converts JUnit/Hamcrest assertions to AssertJ. This is the largest diff -- keeping it separate from the JUnit migration makes review manageable. |
+| 4 | [Upgrade to JUnit 6](./junit6-best-practices.md) | Requires Java 17+. Only run this once your project is already on JUnit 5. |
+| 5 | [Upgrade test code to Java 25](./java-25-for-tests.md) | Adopts text blocks, `SequencedCollection`, etc. in test code only. A safe way to start using modern Java before upgrading production code. |
+
+:::tip
+
+For a large portfolio (50+ repos), steps 1-3 deliver the highest impact. Steps 4-5 can wait until the team is comfortable with the new patterns.
+
+Each step takes roughly 5-15 minutes per repository: run the recipe, review the diff, run the tests, and merge.
+
+:::
+
+## Tips for large-scale rollout
+
+- **Start with a pilot project** -- pick a small, well-tested repo to validate each recipe before rolling out broadly.
+- **One recipe per PR** -- keep each step in its own pull request for clean history and easy reverts.
+- **Run tests before and after** -- recipes are well-tested, but always verify that your tests still pass.
+- **Use CI to enforce new patterns** -- see the [Encourage usage](../adopt-assertj/encourage-usage.md) page for GitHub Actions examples that prevent regression to old patterns.


### PR DESCRIPTION
## Summary
- Intro page: converted section list to a table with per-section time estimates and difficulty levels, added a "quick wins" track tip for sections 1-4, and clarified the JUnit Jupiter description to mention both JUnit 5 and JUnit 6.
- New `upgrade-your-projects/rollout-order.md` page: recommended 5-step sequence for upgrading multiple repos, adapted to reference existing medan-v1 pages (`change-test-method-signatures`, `junit6-best-practices`, `java-25-for-tests`, `encourage-usage`).
- `recipe-development.md`: replaced `-Drewrite.*` flags with `--define rewrite.*` on the Maven CLI example for consistency with the `RunRecipe` component.

## Test plan
- [x] `npm run build` in `site/` completes successfully.
- [ ] Visually verify the intro table and new rollout page render as expected.
- [ ] Verify internal links on the new rollout page resolve.