### PR TITLE
Group OpenRewrite Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      openrewrite:
+        patterns:
+          - "org.openrewrite*:*"
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:


### PR DESCRIPTION
## Summary
- Adds a Dependabot `groups` rule matching `org.openrewrite*:*` so weekly bumps of the recipe modules (jackson, java-dependencies, logging-frameworks, migrate-java, static-analysis, testing-frameworks, spring, etc.) arrive as one combined PR instead of one per artifact.

## Note
- Initially explored using `rewrite-recipe-bom` to manage versions in the root `pom.xml`, but Maven's project-level `<dependencyManagement>` does not apply to plugin-scoped `<dependencies>`, so grouping at the Dependabot layer is the working solution.