### PR TITLE
Add further learning page under Recipe development

### DIFF
--- a/site/docs/recipe-development/further-learning.md
+++ b/site/docs/recipe-development/further-learning.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 3
+---
+
+# Further learning
+
+This workshop only scratches the surface of recipe development.
+To deepen your skills, work through the dedicated hands-on learning modules from Moderne, available at [docs.moderne.io/hands-on-learning](https://docs.moderne.io/hands-on-learning).
+
+## Hands-on learning modules
+
+- [Introduction to OpenRewrite](https://docs.moderne.io/hands-on-learning/introduction/workshop-overview): Foundational workshop covering LSTs, visitors, recipes, Moderne CLI setup, YAML recipe building, and DevCenter migration tracking.
+- [Fundamentals of Recipe Development](https://docs.moderne.io/hands-on-learning/fundamentals/workshop-overview): Custom recipe creation using YAML, Refaster, and imperative Java approaches, including testing and preconditions.
+- [Advanced Recipe Development](https://docs.moderne.io/hands-on-learning/advanced/workshop-overview): Scanning recipes, data tables for code insights, traits, debugging techniques, and workflow composition.
+- [Preparing for a Spring Boot Migration](https://docs.moderne.io/hands-on-learning/spring-boot-migration/workshop-overview): Plan and execute Spring Boot 4 migrations, including dry runs, version detection, and handling blockers.
+- [AI-assisted Recipe Authoring](https://docs.moderne.io/hands-on-learning/ai-recipes/workshop-overview): Use AI as a co-author for building migration recipes with a test-driven workflow.
+
+## Live training and community
+
+- [Monthly OpenRewrite training sessions](https://www.moderne.ai/moderne-openrewrite-training-hub): Sign up for free live training sessions.
+- [OpenRewrite community Slack](https://join.slack.com/t/rewriteoss/shared_invite/zt-nj42n3ea-b~62rIHzb3Vo0E1APKCXEA): Ask questions and share knowledge with the community.
+- [OpenRewrite Discord](https://discord.gg/xk3ZKrhWAb): Chat with other recipe authors.
+
+## Reference documentation
+
+- [OpenRewrite Documentation](https://docs.openrewrite.org/): Official documentation for OpenRewrite, including recipes and usage instructions.
+- [Authoring Recipes](https://docs.openrewrite.org/authoring-recipes): Deep-dive guides for writing recipes by hand.
+- [Refaster User Guide](https://errorprone.info/docs/refaster): Reference for the Refaster template syntax.


### PR DESCRIPTION
## Summary
- Adds a new `Further learning` page under the Recipe development section linking to the hands-on learning modules at docs.moderne.io/hands-on-learning, plus live training, community channels, and OpenRewrite reference docs.