### PR TITLE
Resolve OpenRewrite artifacts from Code Genome Project

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,12 @@ jobs:
     name: Build and verify
     runs-on: ubuntu-latest
 
+    # Activates the codegenome profile in pom.xml; empty on pull requests from forks, which
+    # receive no secrets, leaving the profile inactive so those builds resolve from Central.
+    env:
+      CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+      CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -28,6 +34,9 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
 
       - name: Build with Maven
         run: mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -63,4 +63,33 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>codegenome</id>
+            <activation>
+                <property>
+                    <name>env.CODEGENOME_USERNAME</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Adds a `codegenome` profile to the root `pom.xml` that resolves OpenRewrite artifacts from `https://artifacts.codegenomeproject.org/maven`, mirroring the pattern already used in `openrewrite/rewrite-maven-plugin`. The profile is activated by the presence of `env.CODEGENOME_USERNAME`, so it stays inactive for fork pull requests and local builds, which continue to resolve from Maven Central. The Maven workflow supplies those credentials via `actions/setup-java` (`server-id: codegenome`) from the org secrets `CGP_ARTIFACTS_MAVEN_USERNAME` / `CGP_ARTIFACTS_MAVEN_TOKEN`.

Note that this repository depends on seven `org.openrewrite.recipe:*` artifacts, a group `rewrite-maven-plugin` itself never pulls from Code Genome — so CI here exercises token entitlement that upstream does not. If the org token is not entitled to that group, the build will fail with `403 Forbidden` on those artifacts (Maven treats a 403 as fatal rather than falling through to Central); CI on this PR is the check for that.