### PR TITLE
Point the codegenome Maven credentials at the renamed secrets

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,8 +21,8 @@ jobs:
     # Activates the codegenome profile in pom.xml; empty on pull requests from forks, which
     # receive no secrets, leaving the profile inactive so those builds resolve from Central.
     env:
-      CODEGENOME_USERNAME: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
-      CODEGENOME_TOKEN: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+      CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+      CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- Follows openrewrite/gh-automation#109, which renamed `CGP_ARTIFACTS_MAVEN_USERNAME`/`CGP_ARTIFACTS_MAVEN_TOKEN` to `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN`.

Unlike the Gradle consumers, only the right-hand side changes here. The `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` env var names must stay as they are: they activate the `codegenome` profile in `pom.xml` via `env.CODEGENOME_USERNAME`, and `setup-java` binds them through `server-username`/`server-password`. They were already named after the new secrets while still reading the old ones, so this repo was half-migrated; this completes it.